### PR TITLE
Add .NET Standard 2.0 + Update HarfBuzzSharp = Xamarin Support

### DIFF
--- a/Topten.RichTextKit/Topten.RichTextKit.csproj
+++ b/Topten.RichTextKit/Topten.RichTextKit.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="1.68.0" />
-    <PackageReference Include="SkiaSharp.HarfBuzz" Version="1.68.0" />
+    <PackageReference Include="HarfBuzzSharp" Version="2.6.1-rc.172" />
   </ItemGroup>
 
 </Project>

--- a/Topten.RichTextKit/Topten.RichTextKit.csproj
+++ b/Topten.RichTextKit/Topten.RichTextKit.csproj
@@ -3,7 +3,7 @@
   <Import Project="../common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.0;net45</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).xml</DocumentationFile>
     <Authors>Topten Software</Authors>


### PR DESCRIPTION
A small PR to basically add .NET Standard 2.0, which _almost_ gives us Xamarin.iOS and Xamarin.Android support. The main issue is that p/invoke, which goes away when we update HarfBuzzSharp.

After all that, you legit have the greatest text library out there!

I also "dropped" the SkiaSharp.HarfBuzz NuGet and just use the HarfBuzzSharp NuGet so there are no unnecessary dependencies.

Let me know what you think.

> The preview version should be stable very soon if all the test go well.