### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,10 @@
+trigger:
+- master
+
+pool:
+  name: Hosted Windows 2019 with VS2019
+
+steps:
+- checkout: self
+  submodules: true
+- pwsh: node build.js

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,3 +8,7 @@ steps:
 - checkout: self
   submodules: true
 - pwsh: node build.js
+- task: PublishBuildArtifacts@1
+  inputs:
+    pathToPublish: 'Build\Release\Topten.RichTextKit'
+    artifactName: 'BuildOutput'


### PR DESCRIPTION
This small PR will hook up the build to CI. You can go from there and do releases and everything.

I just used powershell, but you can use `script` and that will use batch. Also, you can do whatever you want:
https://docs.microsoft.com/en-us/azure/devops/pipelines

You can even have a badge:
[![Build Status](https://dev.azure.com/mattleibow/OpenSource/_apis/build/status/RichTextKit?branchName=azure-pipelines)](https://dev.azure.com/mattleibow/OpenSource/_build/latest?definitionId=28&branchName=azure-pipelines)

Free for open source!

This is my build: https://dev.azure.com/mattleibow/OpenSource/_build?definitionId=28&_a=summary