### PR TITLE
FontRun background color suport

### DIFF
--- a/Topten.RichTextKit/FontRun.cs
+++ b/Topten.RichTextKit/FontRun.cs
@@ -674,6 +674,23 @@ namespace Topten.RichTextKit
                 }
             }
         }
+        
+        /// <summary>
+        /// Paint background of this font run
+        /// </summary>
+        /// <param name="ctx"></param>
+        internal void PaintBackground(PaintTextContext ctx)
+        {
+            if (Style.BackgroundColor != SKColor.Empty && RunKind == FontRunKind.Normal)
+            {
+                var rect = new SKRect(XCoord , Line.YCoord, 
+                    XCoord + Width, Line.YCoord + Line.Height);
+                using (var skPaint = new SKPaint {Style = SKPaintStyle.Fill, Color = Style.BackgroundColor})
+                {
+                    ctx.Canvas.DrawRect(rect, skPaint);
+                }
+            }            
+        }
 
         SKTextBlob _textBlob;
         SKFont _font;

--- a/Topten.RichTextKit/IStyle.cs
+++ b/Topten.RichTextKit/IStyle.cs
@@ -67,6 +67,11 @@ namespace Topten.RichTextKit
         /// The text color for text in this run.
         /// </summary>
         SKColor TextColor { get; }
+        
+        /// <summary>
+        /// The background color of this run.
+        /// </summary>
+        SKColor BackgroundColor { get; }
 
         /// <summary>
         /// Extra spacing between each character

--- a/Topten.RichTextKit/IStyleExtensions.cs
+++ b/Topten.RichTextKit/IStyleExtensions.cs
@@ -31,7 +31,7 @@ namespace Topten.RichTextKit
         /// <returns>A key string</returns>
         public static string Key(this IStyle This)
         {
-            return $"{This.FontFamily}.{This.FontSize}.{This.FontWeight}.{This.FontItalic}.{This.Underline}.{This.StrikeThrough}.{This.LineHeight}.{This.TextColor}.{This.LetterSpacing}.{This.FontVariant}.{This.TextDirection}.{This.ReplacementCharacter}";
+            return $"{This.FontFamily}.{This.FontSize}.{This.FontWeight}.{This.FontItalic}.{This.Underline}.{This.StrikeThrough}.{This.LineHeight}.{This.TextColor}.{This.BackgroundColor}.{This.LetterSpacing}.{This.FontVariant}.{This.TextDirection}.{This.ReplacementCharacter}";
         }
 
         /// <summary>
@@ -80,6 +80,8 @@ namespace Topten.RichTextKit
             if (!This.HasSameLayout(other))
                 return false;
             if (This.TextColor != other.TextColor)
+                return false;
+            if (This.BackgroundColor != other.BackgroundColor)
                 return false;
             if (This.Underline != other.Underline)
                 return false;

--- a/Topten.RichTextKit/Style.cs
+++ b/Topten.RichTextKit/Style.cs
@@ -112,6 +112,19 @@ namespace Topten.RichTextKit
             get => _textColor;
             set { CheckNotSealed(); _textColor = value; }
         }
+        
+        /// <summary>
+        /// The background color of this run (no background is painted by default).
+        /// </summary>
+        public SKColor BackgroundColor
+        {
+            get => _backgroundColor;
+            set
+            {
+                CheckNotSealed();
+                _backgroundColor = value;
+            }
+        }
 
         /// <summary>
         /// The character spacing for text in this run (defaults to 0).
@@ -157,6 +170,7 @@ namespace Topten.RichTextKit
         StrikeThroughStyle _strikeThrough;
         float _lineHeight = 1.0f;
         SKColor _textColor = new SKColor(0xFF000000);
+        SKColor _backgroundColor = SKColor.Empty;
         float _letterSpacing;
         FontVariant _fontVariant;
         TextDirection _textDirection = TextDirection.Auto;

--- a/Topten.RichTextKit/Style.cs
+++ b/Topten.RichTextKit/Style.cs
@@ -192,6 +192,7 @@ namespace Topten.RichTextKit
         /// <param name="strikeThrough">The new strike-through style</param>
         /// <param name="lineHeight">The new line height</param>
         /// <param name="textColor">The new text color</param>
+        /// <param name="backgroundColor">The new background color</param>
         /// <param name="letterSpacing">The new letterSpacing</param>
         /// <param name="fontVariant">The new font variant</param>
         /// <param name="textDirection">The new text direction</param>
@@ -206,6 +207,7 @@ namespace Topten.RichTextKit
                StrikeThroughStyle? strikeThrough = null,
                float? lineHeight = null,
                SKColor? textColor = null,
+               SKColor? backgroundColor = null,
                float? letterSpacing = null,
                FontVariant? fontVariant = null,
                TextDirection? textDirection = null,
@@ -223,6 +225,7 @@ namespace Topten.RichTextKit
                 StrikeThrough = strikeThrough ?? this.StrikeThrough,
                 LineHeight = lineHeight ?? this.LineHeight,
                 TextColor = textColor ?? this.TextColor,
+                BackgroundColor = backgroundColor ?? this.BackgroundColor,
                 LetterSpacing = letterSpacing ?? this.LetterSpacing,
                 FontVariant = fontVariant ?? this.FontVariant,
                 TextDirection = textDirection ?? this.TextDirection,

--- a/Topten.RichTextKit/StyleManager.cs
+++ b/Topten.RichTextKit/StyleManager.cs
@@ -83,7 +83,7 @@ namespace Topten.RichTextKit
                 return value;
 
             return Update(value.FontFamily, value.FontSize, value.FontWeight, value.FontItalic,
-                            value.Underline, value.StrikeThrough, value.LineHeight, value.TextColor,
+                            value.Underline, value.StrikeThrough, value.LineHeight, value.TextColor, value.BackgroundColor,
                             value.LetterSpacing, value.FontVariant, value.TextDirection, value.ReplacementCharacter);
         }
 
@@ -218,6 +218,7 @@ namespace Topten.RichTextKit
         /// <param name="strikeThrough">The new strike-through style</param>
         /// <param name="lineHeight">The new line height</param>
         /// <param name="textColor">The new text color</param>
+        /// <param name="backgroundColor">The new text color</param>
         /// <param name="letterSpacing">The new letterSpacing</param>
         /// <param name="fontVariant">The new font variant</param>
         /// <param name="textDirection">The new text direction</param>
@@ -232,6 +233,7 @@ namespace Topten.RichTextKit
                StrikeThroughStyle? strikeThrough = null,
                float? lineHeight = null,
                SKColor? textColor = null,
+               SKColor? backgroundColor = null,
                float? letterSpacing = null,
                FontVariant? fontVariant = null,
                TextDirection? textDirection = null,
@@ -247,13 +249,14 @@ namespace Topten.RichTextKit
             var rStrikeThrough = strikeThrough ?? _currentStyle.StrikeThrough;
             var rLineHeight = lineHeight ?? _currentStyle.LineHeight;
             var rTextColor = textColor ?? _currentStyle.TextColor;
+            var rBackgroundColor = backgroundColor ?? _currentStyle.BackgroundColor;
             var rLetterSpacing = letterSpacing ?? _currentStyle.LetterSpacing;
             var rFontVariant = fontVariant ?? _currentStyle.FontVariant;
             var rTextDirection = textDirection ?? _currentStyle.TextDirection;
             var rReplacementCharacter = replacementCharacter ?? _currentStyle.ReplacementCharacter;
 
             // Format key
-            var key = $"{rFontFamily}.{rFontSize}.{rFontWeight}.{rFontItalic}.{rUnderline}.{rStrikeThrough}.{rLineHeight}.{rTextColor}.{rLetterSpacing}.{rFontVariant}.{rTextDirection}.{rReplacementCharacter}";
+            var key = $"{rFontFamily}.{rFontSize}.{rFontWeight}.{rFontItalic}.{rUnderline}.{rStrikeThrough}.{rLineHeight}.{rTextColor}.{rBackgroundColor}.{rLetterSpacing}.{rFontVariant}.{rTextDirection}.{rReplacementCharacter}";
 
             // Look up...
             if (!_styleMap.TryGetValue(key, out var style))
@@ -270,6 +273,7 @@ namespace Topten.RichTextKit
                     StrikeThrough = rStrikeThrough,
                     LineHeight = rLineHeight,
                     TextColor = rTextColor,
+                    BackgroundColor = rBackgroundColor,
                     LetterSpacing = rLetterSpacing,
                     FontVariant = rFontVariant,
                     TextDirection = rTextDirection,

--- a/Topten.RichTextKit/TextLine.cs
+++ b/Topten.RichTextKit/TextLine.cs
@@ -164,6 +164,11 @@ namespace Topten.RichTextKit
         {
             foreach (var r in Runs)
             {
+                r.PaintBackground(ctx);
+            }
+            
+            foreach (var r in Runs)
+            {
                 r.Paint(ctx);
             }
         }


### PR DESCRIPTION
Hi Brad @toptensoftware !

Please review PR for FontRun background color support. According to my experiments background of all font runs should be drawn before glyphs rendering (FontRun.Paint) because sometimes a glyph overlaps background of a neighbour glyph.

result
![richTextBackground](https://user-images.githubusercontent.com/13216814/101912607-0a302e00-3bd3-11eb-9810-82ecffd3153f.png)

screen shot with a glyph overlapping its neighbour background from Pages for the reference. (the same behaviour as in proposed PR)

![backgroundInPages](https://user-images.githubusercontent.com/13216814/101912698-259b3900-3bd3-11eb-8b71-cade13b1f6d1.png)
