### PR TITLE
FontMetrics.Leading support

### DIFF
--- a/Topten.RichTextKit/FontRun.cs
+++ b/Topten.RichTextKit/FontRun.cs
@@ -129,6 +129,12 @@ namespace Topten.RichTextKit
 
 
         /// <summary>
+        /// The leading of the font used in this run
+        /// </summary>
+        public float Leading;
+
+
+        /// <summary>
         /// The height of text in this run (ascent + descent)
         /// </summary>
         public float TextHeight => -Ascent + Descent;
@@ -136,7 +142,7 @@ namespace Topten.RichTextKit
         /// <summary>
         /// Calculate the half leading height for text in this run
         /// </summary>
-        public float HalfLeading => (TextHeight * Style.LineHeight - TextHeight) / 2;
+        public float HalfLeading => (TextHeight * (Style.LineHeight - 1) + Leading) / 2;
 
         /// <summary>
         /// Width of this typeface run
@@ -337,6 +343,7 @@ namespace Topten.RichTextKit
             newRun.Direction = this.Direction;
             newRun.Ascent = this.Ascent;
             newRun.Descent = this.Descent;
+            newRun.Leading = this.Leading;
             newRun.Style = this.Style;
             newRun.Typeface = this.Typeface;
             newRun.Start = splitAtCodePoint;
@@ -408,6 +415,7 @@ namespace Topten.RichTextKit
             newRun.Direction = this.Direction;
             newRun.Ascent = this.Ascent;
             newRun.Descent = this.Descent;
+            newRun.Leading = this.Leading;
             newRun.Style = this.Style;
             newRun.Typeface = this.Typeface;
             newRun.Start = splitAtCodePoint;

--- a/Topten.RichTextKit/TextBlock.cs
+++ b/Topten.RichTextKit/TextBlock.cs
@@ -1302,6 +1302,7 @@ namespace Topten.RichTextKit
             fontRun.Clusters = shaped.Clusters;
             fontRun.Ascent = shaped.Ascent;
             fontRun.Descent = shaped.Descent;
+            fontRun.Leading = shaped.Leading;
             fontRun.Width = shaped.EndXCoord.X;
             return fontRun;
         }

--- a/Topten.RichTextKit/TextShaping/TextShaper.cs
+++ b/Topten.RichTextKit/TextShaping/TextShaper.cs
@@ -191,6 +191,11 @@ namespace Topten.RichTextKit
             public float Descent;
 
             /// <summary>
+            /// The leading of the font
+            /// </summary>
+            public float Leading;
+
+            /// <summary>
             /// The XMin for the font
             /// </summary>
             public float XMin;
@@ -247,11 +252,8 @@ namespace Topten.RichTextKit
 
             // Also return the end cursor position
             r.EndXCoord = new SKPoint(xCoord * glyphScale, 0);
-
-            // And some other useful metrics
-            r.Ascent = _fontMetrics.Ascent * style.FontSize / overScale;
-            r.Descent = _fontMetrics.Descent * style.FontSize / overScale;
-            r.XMin = _fontMetrics.XMin * style.FontSize / overScale;
+            
+            ApplyFontMetrics(ref r, style.FontSize);
 
             return r;
         }
@@ -467,13 +469,20 @@ namespace Topten.RichTextKit
                 r.EndXCoord = new SKPoint(cursorX, cursorY);
 
                 // And some other useful metrics
-                r.Ascent = _fontMetrics.Ascent * style.FontSize / overScale;
-                r.Descent = _fontMetrics.Descent * style.FontSize / overScale;
-                r.XMin = _fontMetrics.XMin * style.FontSize / overScale;
+                ApplyFontMetrics(ref r, style.FontSize);
 
                 // Done
                 return r;
             }
+        }
+
+        private void ApplyFontMetrics(ref Result result, float fontSize)
+        {
+            // And some other useful metrics
+            result.Ascent = _fontMetrics.Ascent * fontSize / overScale;
+            result.Descent = _fontMetrics.Descent * fontSize / overScale;
+            result.Leading = _fontMetrics.Leading * fontSize / overScale;
+            result.XMin = _fontMetrics.XMin * fontSize / overScale;
         }
 
         private static Blob GetHarfBuzzBlob(SKStreamAsset asset)


### PR DESCRIPTION
Most of the fonts have fontMetrics.Leading equal to 0, but some of them, for example [Permanent Marker](https://fonts.google.com/specimen/Permanent+Marker) have it.

@toptensoftware could you please review PR. Do changes make sense ?