### PR TITLE
Added Halo for FontRun

### DIFF
--- a/SandboxDriver/SandboxDriver.cs
+++ b/SandboxDriver/SandboxDriver.cs
@@ -71,7 +71,8 @@ namespace SandboxDriver
             var styleBoldLarge = styleNormal.Modify(fontSize: 28 * Scale, fontWeight: 700);
             var styleRed = styleNormal.Modify(textColor: new SKColor(0xFFFF0000));
             var styleBlue = styleNormal.Modify(textColor: new SKColor(0xFF0000FF));
-            var styleFontAwesome = new Style() { FontFamily = "FontAwesome", FontSize = 24 * Scale};
+            var styleFontAwesome = new Style() { FontFamily = "FontAwesome", FontSize = 24 * Scale };
+            var styleHalo = styleNormal.Modify(haloColor: SKColors.Gray, haloWidth: 5, haloBlur: 0);
 
 
             _textBlock.Clear();
@@ -111,6 +112,14 @@ namespace SandboxDriver
                     _textBlock.AddText("Font fallback means emojis work: 🙍‍♀️ 🌐 🍪 🍕 🚀 and ", styleNormal);
                     _textBlock.AddText("text shaping and bi-directional text support means complex scripts and languages like Arabic: مرحبا بالعالم, Japanese: ハローワールド, Chinese: 世界您好 and Hindi: हैलो वर्ल्ड are rendered correctly!\n\n", styleNormal);
                     _textBlock.AddText("RichTextKit also supports left/center/right text alignment, word wrapping, truncation with ellipsis place-holder, text measurement, hit testing, painting a selection range, caret position & shape helpers.", styleNormal);
+                    _textBlock.AddText(".\n\n", styleNormal);
+                    _textBlock.AddText("RichTextKit ", styleHalo);
+                    styleHalo = styleHalo.Modify(haloColor: SKColors.Red, haloWidth: 2, haloBlur: 0);
+                    _textBlock.AddText("also", styleHalo);
+                    styleHalo = styleHalo.Modify(haloColor: SKColors.Green, haloWidth: 2, haloBlur: 1);
+                    _textBlock.AddText(" supports ", styleHalo);
+                    styleHalo = styleHalo.Modify(fontWeight: 700, haloColor: SKColors.Blue, haloWidth: 5, haloBlur: 5);
+                    _textBlock.AddText("halo.", styleHalo);
                     break;
 
                 case 1:

--- a/Topten.RichTextKit/IStyle.cs
+++ b/Topten.RichTextKit/IStyle.cs
@@ -74,6 +74,21 @@ namespace Topten.RichTextKit
         SKColor BackgroundColor { get; }
 
         /// <summary>
+        /// Color of the halo
+        /// </summary>
+        SKColor HaloColor { get; }
+
+        /// <summary>
+        /// Width of halo
+        /// </summary>
+        float HaloWidth { get; }
+
+        /// <summary>
+        /// Blur of halo
+        /// </summary>
+        float HaloBlur { get; }
+
+        /// <summary>
         /// Extra spacing between each character
         /// </summary>
         float LetterSpacing { get; }

--- a/Topten.RichTextKit/RichString.cs
+++ b/Topten.RichTextKit/RichString.cs
@@ -59,6 +59,9 @@ namespace Topten.RichTextKit
         /// <param name="lineHeight">The new line height</param>
         /// <param name="textColor">The new text color</param>
         /// <param name="backgroundColor">The new background color</param>
+        /// <param name="haloColor">The new halo color</param>
+        /// <param name="haloWidth">The new halo width</param>
+        /// <param name="haloBlur">The new halo blur width</param>
         /// <param name="letterSpacing">The new character spacing</param>
         /// <param name="fontVariant">The new font variant</param>
         /// <param name="textDirection">The new text direction</param>
@@ -73,6 +76,9 @@ namespace Topten.RichTextKit
            float? lineHeight = null,
            SKColor? textColor = null,
            SKColor? backgroundColor = null,
+           SKColor? haloColor = null,
+           float? haloWidth = null,
+           float? haloBlur = null,
            float? letterSpacing = null,
            FontVariant? fontVariant = null,
            TextDirection? textDirection = null
@@ -91,6 +97,9 @@ namespace Topten.RichTextKit
             if (lineHeight.HasValue) LineHeight(lineHeight.Value);
             if (textColor.HasValue) TextColor(textColor.Value);
             if (backgroundColor.HasValue) BackgroundColor(backgroundColor.Value);
+            if (haloColor.HasValue) HaloColor(haloColor.Value);
+            if (haloWidth.HasValue) HaloWidth(haloWidth.Value);
+            if (haloBlur.HasValue) HaloBlur(haloBlur.Value);
             if (fontVariant.HasValue) FontVariant(fontVariant.Value);
             if (letterSpacing.HasValue) LetterSpacing(letterSpacing.Value);
             if (textDirection.HasValue) TextDirection(textDirection.Value);
@@ -170,6 +179,27 @@ namespace Topten.RichTextKit
         /// <param name="value">The new background color</param>
         /// <returns>A reference to the same RichString instance</returns>
         public RichString BackgroundColor(SKColor value) => Append(new BackgroundColorItem(value));
+
+        /// <summary>
+        /// Changes the halo color
+        /// </summary>
+        /// <param name="value">The new halo color</param>
+        /// <returns>A reference to the same RichString instance</returns>
+        public RichString HaloColor(SKColor value) => Append(new HaloColorItem(value));
+
+        /// <summary>
+        /// Changes the halo width
+        /// </summary>
+        /// <param name="value">The new halo width</param>
+        /// <returns>A reference to the same RichString instance</returns>
+        public RichString HaloWidth(float value) => Append(new HaloWidthItem(value));
+
+        /// <summary>
+        /// Changes the halo blur width
+        /// </summary>
+        /// <param name="value">The new halo blur width</param>
+        /// <returns>A reference to the same RichString instance</returns>
+        public RichString HaloBlur(float value) => Append(new HaloBlurItem(value));
 
         /// <summary>
         /// Changes the character spacing
@@ -1187,6 +1217,51 @@ namespace Topten.RichTextKit
             public override void Build(BuildContext ctx)
             {
                 ctx.StyleManager.BackgroundColor(_value);
+            }
+        }
+
+        class HaloColorItem : Item
+        {
+            public HaloColorItem(SKColor value)
+            {
+                _value = value;
+            }
+
+            SKColor _value;
+
+            public override void Build(BuildContext ctx)
+            {
+                ctx.StyleManager.HaloColor(_value);
+            }
+        }
+
+        class HaloWidthItem : Item
+        {
+            public HaloWidthItem(float value)
+            {
+                _value = value;
+            }
+
+            float _value;
+
+            public override void Build(BuildContext ctx)
+            {
+                ctx.StyleManager.HaloWidth(_value);
+            }
+        }
+
+        class HaloBlurItem : Item
+        {
+            public HaloBlurItem(float value)
+            {
+                _value = value;
+            }
+
+            float _value;
+
+            public override void Build(BuildContext ctx)
+            {
+                ctx.StyleManager.HaloBlur(_value);
             }
         }
 

--- a/Topten.RichTextKit/Style.cs
+++ b/Topten.RichTextKit/Style.cs
@@ -127,6 +127,45 @@ namespace Topten.RichTextKit
         }
 
         /// <summary>
+        /// Color of the halo
+        /// </summary>
+        public SKColor HaloColor
+        {
+            get => _haloColor;
+            set
+            {
+                CheckNotSealed();
+                _haloColor = value;
+            }
+        }
+
+        /// <summary>
+        /// Width of halo
+        /// </summary>
+        public float HaloWidth
+        {
+            get => _haloWidth;
+            set
+            {
+                CheckNotSealed();
+                _haloWidth = value;
+            }
+        }
+
+        /// <summary>
+        /// Blur of halo
+        /// </summary>
+        public float HaloBlur
+        {
+            get => _haloBlur;
+            set
+            {
+                CheckNotSealed();
+                _haloBlur = value;
+            }
+        }
+
+        /// <summary>
         /// The character spacing for text in this run (defaults to 0).
         /// </summary>
         public float LetterSpacing
@@ -171,6 +210,9 @@ namespace Topten.RichTextKit
         float _lineHeight = 1.0f;
         SKColor _textColor = new SKColor(0xFF000000);
         SKColor _backgroundColor = SKColor.Empty;
+        SKColor _haloColor = SKColor.Empty;
+        float _haloWidth = 0f;
+        float _haloBlur = 0f;
         float _letterSpacing;
         FontVariant _fontVariant;
         TextDirection _textDirection = TextDirection.Auto;
@@ -208,6 +250,9 @@ namespace Topten.RichTextKit
                float? lineHeight = null,
                SKColor? textColor = null,
                SKColor? backgroundColor = null,
+               SKColor? haloColor = null,
+               float? haloWidth = null,
+               float? haloBlur = null,
                float? letterSpacing = null,
                FontVariant? fontVariant = null,
                TextDirection? textDirection = null,
@@ -226,6 +271,9 @@ namespace Topten.RichTextKit
                 LineHeight = lineHeight ?? this.LineHeight,
                 TextColor = textColor ?? this.TextColor,
                 BackgroundColor = backgroundColor ?? this.BackgroundColor,
+                HaloColor = haloColor ?? this.HaloColor,
+                HaloWidth = haloWidth ?? this.HaloWidth,
+                HaloBlur = haloBlur ?? this.HaloBlur,
                 LetterSpacing = letterSpacing ?? this.LetterSpacing,
                 FontVariant = fontVariant ?? this.FontVariant,
                 TextDirection = textDirection ?? this.TextDirection,

--- a/Topten.RichTextKit/StyleManager.cs
+++ b/Topten.RichTextKit/StyleManager.cs
@@ -14,9 +14,7 @@
 // under the License.
 
 using SkiaSharp;
-using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 
 namespace Topten.RichTextKit
@@ -84,6 +82,7 @@ namespace Topten.RichTextKit
 
             return Update(value.FontFamily, value.FontSize, value.FontWeight, value.FontItalic,
                             value.Underline, value.StrikeThrough, value.LineHeight, value.TextColor, value.BackgroundColor,
+                            value.HaloColor, value.HaloWidth, value.HaloBlur,
                             value.LetterSpacing, value.FontVariant, value.TextDirection, value.ReplacementCharacter);
         }
 
@@ -185,6 +184,27 @@ namespace Topten.RichTextKit
         public IStyle BackgroundColor(SKColor backgroundColor) => Update(backgroundColor: backgroundColor);
 
         /// <summary>
+        /// Changes the halo color and returns an updated IStyle
+        /// </summary>
+        /// <param name="haloColor">The new halo color</param>
+        /// <returns>An IStyle for the new style</returns>
+        public IStyle HaloColor(SKColor haloColor) => Update(haloColor: haloColor);
+
+        /// <summary>
+        /// Changes the halo width and returns an updated IStyle
+        /// </summary>
+        /// <param name="haloWidth">The new halo width</param>
+        /// <returns>An IStyle for the new style</returns>
+        public IStyle HaloWidth(float haloWidth) => Update(haloWidth: haloWidth);
+
+        /// <summary>
+        /// Changes the halo blur width and returns an updated IStyle
+        /// </summary>
+        /// <param name="haloBlur">The new halo blur width</param>
+        /// <returns>An IStyle for the new style</returns>
+        public IStyle HaloBlur(float haloBlur) => Update(haloBlur: haloBlur);
+
+        /// <summary>
         /// Changes the character spacing and returns an updated IStyle
         /// </summary>
         /// <param name="letterSpacing">The new character spacing</param>
@@ -226,6 +246,9 @@ namespace Topten.RichTextKit
         /// <param name="lineHeight">The new line height</param>
         /// <param name="textColor">The new text color</param>
         /// <param name="backgroundColor">The new text color</param>
+        /// <param name="haloColor">The new text color</param>
+        /// <param name="haloWidth">The new halo width</param>
+        /// <param name="haloBlur">The new halo blur width</param>
         /// <param name="letterSpacing">The new letterSpacing</param>
         /// <param name="fontVariant">The new font variant</param>
         /// <param name="textDirection">The new text direction</param>
@@ -241,6 +264,9 @@ namespace Topten.RichTextKit
                float? lineHeight = null,
                SKColor? textColor = null,
                SKColor? backgroundColor = null,
+               SKColor? haloColor = null,
+               float? haloWidth = null,
+               float? haloBlur = null,
                float? letterSpacing = null,
                FontVariant? fontVariant = null,
                TextDirection? textDirection = null,
@@ -257,13 +283,16 @@ namespace Topten.RichTextKit
             var rLineHeight = lineHeight ?? _currentStyle.LineHeight;
             var rTextColor = textColor ?? _currentStyle.TextColor;
             var rBackgroundColor = backgroundColor ?? _currentStyle.BackgroundColor;
+            var rHaloColor = haloColor ?? _currentStyle.HaloColor;
+            var rHaloWidth = haloWidth ?? _currentStyle.HaloWidth;
+            var rHaloBlur = haloBlur ?? _currentStyle.HaloBlur;
             var rLetterSpacing = letterSpacing ?? _currentStyle.LetterSpacing;
             var rFontVariant = fontVariant ?? _currentStyle.FontVariant;
             var rTextDirection = textDirection ?? _currentStyle.TextDirection;
             var rReplacementCharacter = replacementCharacter ?? _currentStyle.ReplacementCharacter;
 
             // Format key
-            var key = $"{rFontFamily}.{rFontSize}.{rFontWeight}.{rFontItalic}.{rUnderline}.{rStrikeThrough}.{rLineHeight}.{rTextColor}.{rBackgroundColor}.{rLetterSpacing}.{rFontVariant}.{rTextDirection}.{rReplacementCharacter}";
+            var key = $"{rFontFamily}.{rFontSize}.{rFontWeight}.{rFontItalic}.{rUnderline}.{rStrikeThrough}.{rLineHeight}.{rTextColor}.{rBackgroundColor}.{rHaloColor}.{rHaloWidth}.{rHaloBlur}.{rLetterSpacing}.{rFontVariant}.{rTextDirection}.{rReplacementCharacter}";
 
             // Look up...
             if (!_styleMap.TryGetValue(key, out var style))
@@ -281,6 +310,9 @@ namespace Topten.RichTextKit
                     LineHeight = rLineHeight,
                     TextColor = rTextColor,
                     BackgroundColor = rBackgroundColor,
+                    HaloColor = rHaloColor,
+                    HaloWidth = rHaloWidth,
+                    HaloBlur = rHaloBlur,
                     LetterSpacing = rLetterSpacing,
                     FontVariant = rFontVariant,
                     TextDirection = rTextDirection,


### PR DESCRIPTION
Added Halo to IStyle and Style
Added handling of Halo in FontRun
Added examples to SandboxDriver

This isn't far from perfect. The sizes aren't corrected for the halo. But I assume, that this isn't very important ;-)

Further, I don't know if there are other parts in RichTextKit, that draw anything to canvas.

The result looks like this:

![grafik](https://user-images.githubusercontent.com/4381223/148419851-cc84d10a-eb98-4b33-91c6-0c25d7babd43.png)
