### PR TITLE
Fix strikethrough halo width not being set on the correct paint object

### DIFF
--- a/Topten.RichTextKit/FontRun.cs
+++ b/Topten.RichTextKit/FontRun.cs
@@ -731,12 +731,13 @@ namespace Topten.RichTextKit
 
                         if (Style.HaloColor != SKColor.Empty)
                         {
-                            // Paint strikethrough
+                            // Paint strikethrough halo behind text
                             if (Style.StrikeThrough != StrikeThroughStyle.None && RunKind == FontRunKind.Normal)
                             {
-                                paint.StrokeWidth = _font.Metrics.StrikeoutThickness ?? 1;
-                                if (paint.StrokeWidth < 1)
-                                    paint.StrokeWidth = 1; ;
+                                paintHalo.StrokeWidth = _font.Metrics.StrikeoutThickness ?? 1;
+                                if (paintHalo.StrokeWidth < 1)
+                                    paintHalo.StrokeWidth = 1;
+                                paintHalo.StrokeWidth += Style.HaloWidth;
                                 float strikeYPos = Line.YCoord + Line.BaseLine + (_font.Metrics.StrikeoutPosition ?? 0) + glyphVOffset;
                                 ctx.Canvas.DrawLine(new SKPoint(XCoord, strikeYPos), new SKPoint(XCoord + Width, strikeYPos), paintHalo);
                             }
@@ -747,12 +748,12 @@ namespace Topten.RichTextKit
                     }
                 }
 
-                // Paint strikethrough
+                // Paint strikethrough above text
                 if (Style.StrikeThrough != StrikeThroughStyle.None && RunKind == FontRunKind.Normal)
                 {
                     paint.StrokeWidth = _font.Metrics.StrikeoutThickness ?? 1;
                     if (paint.StrokeWidth < 1)
-                        paint.StrokeWidth = 1; ;
+                        paint.StrokeWidth = 1;
                     float strikeYPos = Line.YCoord + Line.BaseLine + (_font.Metrics.StrikeoutPosition ?? 0) + glyphVOffset;
                     ctx.Canvas.DrawLine(new SKPoint(XCoord, strikeYPos), new SKPoint(XCoord + Width, strikeYPos), paint);
                 }


### PR DESCRIPTION
I noticed that the paint object modified before painting the strikethrough halo is not the one used for the render call. This PR fixes that as well as increases the width by `Style.HaloWidth` which seemed to be missing.