### PR TITLE
Support for overriding vertical font metrics

### DIFF
--- a/Topten.RichTextKit/FontMetricsMapper.cs
+++ b/Topten.RichTextKit/FontMetricsMapper.cs
@@ -1,0 +1,58 @@
+﻿// RichTextKit
+// Copyright © 2019-2020 Topten Software. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you may 
+// not use this product except in compliance with the License. You may obtain 
+// a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the 
+// License for the specific language governing permissions and limitations 
+// under the License.
+
+using SkiaSharp;
+
+namespace Topten.RichTextKit
+{
+    public class VerticalFontMetrics
+    {
+        public float Ascent { get; }
+        public float Descent { get; }
+        public float Leading { get;}
+
+        public VerticalFontMetrics(float ascent, float descent, float leading)
+        {
+            Ascent = ascent;
+            Descent = descent;
+            Leading = leading;
+        }
+    }
+
+    /// <summary>
+    /// The FontMetricsMapper class is responsible for mapping a font to a set of metrics
+    /// which affect its layouting. The default instance can be replaced in cases where different
+    /// layouting is desired.
+    /// </summary>
+    public class FontMetricsMapper
+    {
+        /// <summary>
+        /// The default metrics mapper instance.
+        /// </summary>
+        public static FontMetricsMapper Default = new FontMetricsMapper();
+
+        /// <summary>
+        /// Maps a given typeface and font size to its vertical metrics.
+        /// </summary>
+        /// <param name="typeface">The typeface.</param>
+        /// <param name="fontSize">The font size in pixels.</param>
+        /// <returns>The vertical font metrics.</returns>
+        public virtual VerticalFontMetrics GetVerticalMetrics(SKTypeface typeface, float fontSize)
+        {
+            var fontMetrics = typeface.ToFont(fontSize).Metrics;
+            return new VerticalFontMetrics(fontMetrics.Ascent, fontMetrics.Descent, fontMetrics.Descent);
+        }
+    }
+}

--- a/Topten.RichTextKit/TextShaping/TextShaper.cs
+++ b/Topten.RichTextKit/TextShaping/TextShaper.cs
@@ -79,7 +79,8 @@ namespace Topten.RichTextKit
             {
                 paint.Typeface = typeface;
                 paint.TextSize = overScale;
-                _fontMetrics = paint.FontMetrics;
+                _fontXMin = paint.FontMetrics.XMin;
+                _verticalMetrics = FontMetricsMapper.Default.GetVerticalMetrics(typeface, overScale);
 
                 // This is a temporary hack until SkiaSharp exposes
                 // a way to check if a font is fixed pitch.  For now
@@ -116,9 +117,14 @@ namespace Topten.RichTextKit
         SKTypeface _typeface;
 
         /// <summary>
-        /// Font metrics for the font
+        /// The minimum bounding box x value for the font.
         /// </summary>
-        SKFontMetrics _fontMetrics;
+        float _fontXMin;
+
+        /// <summary>
+        /// The vertical font metrics as provided by the metrics mapper.
+        /// </summary>
+        readonly VerticalFontMetrics _verticalMetrics;
 
         /// <summary>
         /// True if this font face is fixed pitch
@@ -479,10 +485,10 @@ namespace Topten.RichTextKit
         private void ApplyFontMetrics(ref Result result, float fontSize)
         {
             // And some other useful metrics
-            result.Ascent = _fontMetrics.Ascent * fontSize / overScale;
-            result.Descent = _fontMetrics.Descent * fontSize / overScale;
-            result.Leading = _fontMetrics.Leading * fontSize / overScale;
-            result.XMin = _fontMetrics.XMin * fontSize / overScale;
+            result.Ascent = _verticalMetrics.Ascent * fontSize / overScale;
+            result.Descent = _verticalMetrics.Descent * fontSize / overScale;
+            result.Leading = _verticalMetrics.Leading * fontSize / overScale;
+            result.XMin = _fontXMin * fontSize / overScale;
         }
 
         private static Blob GetHarfBuzzBlob(SKStreamAsset asset)


### PR DESCRIPTION
This PR adds the ability to provide custom vertical font metrics when layouting text.

The background here is that Skia report different font metrics depending on platform. Windows uses `usWinAscent`, `usWinDescent`, and this lovely formula for calculating leading: `MAX(0, (hhea.ascender - hhea.descender + hhea.lineGap) - (usWinAscent + usWinDescent))`. If I remember correctly Linux uses the `sTypo*`  metrics.

For cross-platform .NET applications that want to have similar rendering on both Windows and Linux (in particular vertical positioning) there needs to be a way to override the metrics reported by Skia.

I realize this may be out-of-scope for this library, feel free to close the PR in that case.