### PR TITLE
Fixed Incorrect Null Check

### DIFF
--- a/Topten.RichTextKit/Editor/TextDocument.cs
+++ b/Topten.RichTextKit/Editor/TextDocument.cs
@@ -805,7 +805,7 @@ namespace Topten.RichTextKit.Editor
             }
 
             var styledText = new StyledText(codePoints);
-            if (styledText != null)
+            if (styleToUse != null)
             {
                 styledText.ApplyStyle(0, styledText.Length, styleToUse);
             }

--- a/Topten.RichTextKit/Topten.RichTextKit.csproj
+++ b/Topten.RichTextKit/Topten.RichTextKit.csproj
@@ -20,12 +20,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SkiaSharp" Version="2.88.3" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.3" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
== WHAT ==
Modified null check in ReplaceText to check the styleToUse variable.

== WHY ==

This previous commit added ad-hoc styling:
https://github.com/toptensoftware/RichTextKit/commit/beb262ed21087b1600837a56336900f2c24f3b3a

The null check added inadvertently checks "styledText" which was just created instead of checking the "styleToUse" variable before attempting to apply it.  