### PR TITLE
Faster UnicodeTrie startup time

### DIFF
--- a/Topten.RichTextKit/Unicode/UnicodeTrie.cs
+++ b/Topten.RichTextKit/Unicode/UnicodeTrie.cs
@@ -40,10 +40,10 @@ namespace Topten.RichTextKit
             using (var bw = new BinaryReader(infl2, Encoding.UTF8, true))
             {
                 _data = new int[dataLength];
-                for (int i = 0; i < _data.Length; i++)
-                {
-                    _data[i] = bw.ReadInt32();
-                }
+
+                // Read the entire stream, then convert to int[]
+                var byteData = bw.ReadBytes(_data.Length * sizeof(int));
+                Buffer.BlockCopy(byteData, 0, _data, 0, byteData.Length);
             }
         }
 


### PR DESCRIPTION
This change loads the UnicodeTrie stream in one go, rather than one `int` at a time.