### PR TITLE
Fixed several issues

### DIFF
--- a/Topten.RichTextKit/Editor/TextDocument.cs
+++ b/Topten.RichTextKit/Editor/TextDocument.cs
@@ -334,6 +334,54 @@ namespace Topten.RichTextKit.Editor
         }
 
         /// <summary>
+        /// The total width of the content of the document
+        /// </summary>
+        /// <remarks>
+        /// For line-wrap or non-line-wrap documents this is
+        /// the width of the widest paragraph.
+        /// </remarks>
+        public float MeasuredContentWidth
+        {
+            get
+            {
+                Layout();
+                return _measuredWidth;
+            }
+        }
+
+        /// <summary>
+        /// Gets the actual measured overhang in each direction based on the 
+        /// fonts used, and the supplied text.
+        /// </summary>
+        /// <remarks>
+        /// The return rectangle describes overhang amounts for each edge - not 
+        /// rectangle co-ordinates.
+        /// </remarks>
+        public SKRect MeasuredOverhang
+        {
+            get
+            {
+                Layout();
+                if (_paragraphs.Count == 0)
+                    return new SKRect();
+
+                var overhang = _paragraphs[0].TextBlock.MeasuredOverhang;
+                float topOverhang = overhang.Top;
+                float bottomOverhang = _paragraphs[_paragraphs.Count - 1].TextBlock.MeasuredOverhang.Bottom;
+                float leftOverhang = overhang.Left;
+                float rightOverhang = overhang.Right;
+                for (int i = 1; i < _paragraphs.Count; i++)
+                {
+                    overhang = _paragraphs[i].TextBlock.MeasuredOverhang;
+                    leftOverhang = Math.Max(leftOverhang, overhang.Left);
+                    rightOverhang = Math.Max(rightOverhang, overhang.Right);
+                }
+
+                return new SKRect(leftOverhang, topOverhang, rightOverhang, bottomOverhang);
+            }
+        }
+
+        /// <summary>
         /// Gets the total length of the document in code points
         /// </summary>
         public int Length

--- a/Topten.RichTextKit/Editor/TextDocument.cs
+++ b/Topten.RichTextKit/Editor/TextDocument.cs
@@ -419,6 +419,39 @@ namespace Topten.RichTextKit.Editor
         }
 
         /// <summary>
+        /// Get the text for a part of the document
+        /// </summary>
+        /// <param name="range">The text to retrieve</param>
+        /// <returns>The styled text</returns>
+        public StyledText Extract(TextRange range)
+        {
+            var other = new StyledText();
+
+            // Normalize and clamp range
+            range = range.Normalized.Clamp(Length - 1);
+
+            // Get all subruns
+            foreach (var subrun in _paragraphs.GetInterectingRuns(range.Start, range.Length))
+            {
+                // Get the paragraph
+                var para = _paragraphs[subrun.Index];
+                if (para.TextBlock == null)
+                    throw new NotImplementedException();
+
+                var styledText = para.TextBlock.Extract(subrun.Offset, subrun.Length);
+                foreach (var sr in styledText.StyleRuns)
+                {
+                    other.AddText(sr.CodePoints, sr.Style);
+                }
+            }
+
+            // Convert paragraph separators to new lines
+            other.CodePoints.Replace('\u2029', '\n');
+
+            return other;
+        }
+
+        /// <summary>
         /// Handles keyboard navigation events
         /// </summary>
         /// <param name="position">The current caret position</param>
@@ -813,6 +846,37 @@ namespace Topten.RichTextKit.Editor
         }
 
         /// <summary>
+        /// Replaces a range of text with the specified text
+        /// </summary>
+        /// <param name="view">The view initiating the operation</param>
+        /// <param name="range">The range to be replaced</param>
+        /// <param name="styledText">The text to replace with</param>
+        /// <param name="semantics">Controls how undo operations are coalesced and view selections updated</param>"
+        public void ReplaceText(ITextDocumentView view, TextRange range, StyledText styledText, EditSemantics semantics)
+        {
+            // Check range is valid
+            if (range.Minimum < 0 || range.Maximum > this.Length)
+                throw new ArgumentException("Invalid range", nameof(range));
+
+            if (IsImeComposing)
+                FinishImeComposition(view);
+
+            // Convert new lines to paragraph separators
+            if (PlainTextMode)
+                styledText.CodePoints.Replace('\n', '\u2029');
+
+            // Break at the first line break
+            if (SingleLineMode)
+            {
+                int breakPos = styledText.CodePoints.SubSlice(0, styledText.Length).IndexOfAny('\n', '\r', '\u2029');
+                if (breakPos >= 0)
+                    styledText.DeleteText(breakPos, styledText.Length - breakPos);
+            }
+
+            ReplaceTextInternal(view, range, styledText, semantics, -1);
+        }
+
+        /// <summary>
         /// Indicates if an IME composition is currently in progress
         /// </summary>
         public bool IsImeComposing
@@ -973,7 +1037,7 @@ namespace Topten.RichTextKit.Editor
             Layout();
 
             // Search paragraphs
-            int paraIndex = _paragraphs.BinarySearch(position.CodePointIndex, (para, a) => 
+            int paraIndex = _paragraphs.BinarySearch(position.CodePointIndex, (para, a) =>
             {
                 if (a < para.CodePointIndex)
                     return 1;
@@ -1409,6 +1473,7 @@ namespace Topten.RichTextKit.Editor
         bool _layoutValid = false;
         bool _lineWrap = true;
         internal List<Paragraph> _paragraphs;
+
         UndoManager<TextDocument> _undoManager;
         List<ITextDocumentView> _views = new List<ITextDocumentView>();
         ITextDocumentView _initiatingView;

--- a/Topten.RichTextKit/Editor/TextDocument.cs
+++ b/Topten.RichTextKit/Editor/TextDocument.cs
@@ -805,7 +805,7 @@ namespace Topten.RichTextKit.Editor
             }
 
             var styledText = new StyledText(codePoints);
-            if (styledText != null)
+            if (styleToUse != null)
             {
                 styledText.ApplyStyle(0, styledText.Length, styleToUse);
             }

--- a/Topten.RichTextKit/FontRun.cs
+++ b/Topten.RichTextKit/FontRun.cs
@@ -638,11 +638,18 @@ namespace Topten.RichTextKit
                         // Get glyph positions
                         var glyphPositions = GlyphPositions.ToArray();
 
+                        var scaledFontSize = this.Style.FontSize * glyphScale;
+
                         // Create the font
                         if (_font == null)
                         {
-                            _font = new SKFont(this.Typeface, this.Style.FontSize * glyphScale);
+                            _font = new SKFont(this.Typeface, scaledFontSize);
                         }
+                        else if (_font.Size != scaledFontSize)
+                        {
+                            _font.Size = scaledFontSize;
+                        }
+
                         _font.Hinting = ctx.Options.Hinting;
                         _font.Edging = ctx.Options.Edging;
                         _font.Subpixel = ctx.Options.SubpixelPositioning;

--- a/Topten.RichTextKit/FontRun.cs
+++ b/Topten.RichTextKit/FontRun.cs
@@ -464,15 +464,36 @@ namespace Topten.RichTextKit
         /// Calculate any overhang for this text line
         /// </summary>
         /// <param name="right"></param>
+        /// <param name="updateTop">True to update topOverhang.</param>
+        /// <param name="updateBottom">True to update bottomOverhang.</param>
         /// <param name="leftOverhang"></param>
         /// <param name="rightOverhang"></param>
-        internal void UpdateOverhang(float right, ref float leftOverhang, ref float rightOverhang)
+        /// <param name="topOverhang"></param>
+        /// <param name="bottomOverhang"></param>
+        internal void UpdateOverhang(float right, bool updateTop, bool updateBottom, ref float leftOverhang, ref float rightOverhang, ref float topOverhang, ref float bottomOverhang)
         {
             if (RunKind == FontRunKind.TrailingWhitespace)
                 return;
 
             if (Glyphs.Length == 0)
                 return;
+ 
+            if (Style.LineHeight < 1)
+            {
+                // If LineHeight is less than 100%, the line can have top and bottom overhang
+                if (updateTop)
+                {
+                    var toh = -(TextHeight * (Style.LineHeight - 1) / 2);
+                    if (toh > topOverhang)
+                        topOverhang = toh;
+                }
+                if (updateBottom)
+                {
+                    var boh = -(TextHeight * (Style.LineHeight - 1) / 2);
+                    if (boh > bottomOverhang)
+                        bottomOverhang = boh;
+                }
+            }
 
             using (var paint = new SKPaint())
             {
@@ -509,7 +530,7 @@ namespace Topten.RichTextKit
                                     leftOverhang = loh;
 
                                 var roh = (gx + bounds[i].Right + 1) - right;
-                                if (roh > rightOverhang) 
+                                if (roh > rightOverhang)
                                     rightOverhang = roh;
                             }
                         }

--- a/Topten.RichTextKit/FontRun.cs
+++ b/Topten.RichTextKit/FontRun.cs
@@ -741,10 +741,10 @@ namespace Topten.RichTextKit
                                 float strikeYPos = Line.YCoord + Line.BaseLine + (_font.Metrics.StrikeoutPosition ?? 0) + glyphVOffset;
                                 ctx.Canvas.DrawLine(new SKPoint(XCoord, strikeYPos), new SKPoint(XCoord + Width, strikeYPos), paintHalo);
                             }
-                            ctx.Canvas.DrawText(_textBlob, 0, 0, paintHalo);
+                            ctx.Canvas.DrawText(_textBlob, 0, glyphVOffset, paintHalo);
                         }
 
-                        ctx.Canvas.DrawText(_textBlob, 0, 0, paint);
+                        ctx.Canvas.DrawText(_textBlob, 0, glyphVOffset, paint);
                     }
                 }
 

--- a/Topten.RichTextKit/IStyleExtensions.cs
+++ b/Topten.RichTextKit/IStyleExtensions.cs
@@ -31,7 +31,7 @@ namespace Topten.RichTextKit
         /// <returns>A key string</returns>
         public static string Key(this IStyle This)
         {
-            return $"{This.FontFamily}.{This.FontSize}.{This.FontWeight}.{This.FontWidth}.{This.FontItalic}.{This.Underline}.{This.StrikeThrough}.{This.LineHeight}.{This.TextColor}.{This.BackgroundColor}.{This.LetterSpacing}.{This.FontVariant}.{This.TextDirection}.{This.ReplacementCharacter}";
+            return $"{This.FontFamily}.{This.FontSize}.{This.FontWeight}.{This.FontWidth}.{This.FontItalic}.{This.Underline}.{This.StrikeThrough}.{This.LineHeight}.{This.TextColor}.{This.BackgroundColor}.{This.LetterSpacing}.{This.FontVariant}.{This.TextDirection}.{This.ReplacementCharacter}.{This.HaloWidth}.{This.HaloColor}.{This.HaloBlur}";
         }
 
         /// <summary>
@@ -89,10 +89,13 @@ namespace Topten.RichTextKit
                 return false;
             if (This.StrikeThrough != other.StrikeThrough)
                 return false;
+            if (This.HaloBlur != other.HaloBlur)
+                return false;
+            if (This.HaloColor != other.HaloColor)
+                return false;
+            if (This.HaloWidth != other.HaloWidth)
+                return false;
             return true;
         }
-
-
-
     }
 }

--- a/Topten.RichTextKit/StyleManager.cs
+++ b/Topten.RichTextKit/StyleManager.cs
@@ -265,7 +265,7 @@ namespace Topten.RichTextKit
                string fontFamily = null,
                float? fontSize = null,
                int? fontWeight = null,
-               SKFontStyleWidth? fontWidth = 0,
+               SKFontStyleWidth? fontWidth = null,
                bool? fontItalic = null,
                UnderlineStyle? underline = null,
                StrikeThroughStyle? strikeThrough = null,

--- a/Topten.RichTextKit/TextBlock.cs
+++ b/Topten.RichTextKit/TextBlock.cs
@@ -348,6 +348,8 @@ namespace Topten.RichTextKit
             _measuredWidth = 0;
             _leftOverhang = null;
             _rightOverhang = null;
+            _topOverhang = null;
+            _bottomOverhang = null;
             _truncated = false;
 
             // Only layout if actually have some text
@@ -610,14 +612,20 @@ namespace Topten.RichTextKit
                     var right = _maxWidth ?? MeasuredWidth;
                     float leftOverhang = 0;
                     float rightOverhang = 0;
-                    foreach (var l in _lines)
+                    float topOverhang = 0;
+                    float bottomOverhang = 0;
+                    for (int l = 0; l < _lines.Count; l++)
                     {
-                        l.UpdateOverhang(right, ref leftOverhang, ref rightOverhang);
+                        bool updateTop = l == 0;
+                        bool updateBottom = l == (_lines.Count - 1);
+                        _lines[l].UpdateOverhang(right, updateTop, updateBottom, ref leftOverhang, ref rightOverhang, ref topOverhang, ref bottomOverhang);
                     }
                     _leftOverhang = leftOverhang;
                     _rightOverhang = rightOverhang;
+                    _topOverhang = topOverhang;
+                    _bottomOverhang = bottomOverhang;
                 }
-                return new SKRect(_leftOverhang.Value, 0, _rightOverhang.Value, 0);
+                return new SKRect(_leftOverhang.Value, _topOverhang.Value, _rightOverhang.Value, _bottomOverhang.Value);
             }
         }
 
@@ -1033,6 +1041,16 @@ namespace Topten.RichTextKit
         /// The required left overhang
         /// </summary>
         float? _rightOverhang = null;
+
+        /// <summary>
+        /// The required top overhang
+        /// </summary>
+        float? _topOverhang = null;
+
+        /// <summary>
+        /// The required bottom overhang
+        /// </summary>
+        float? _bottomOverhang = null;
 
         /// <summary>
         /// Indicates if the text was truncated by max height/max lines limitations

--- a/Topten.RichTextKit/TextBlock.cs
+++ b/Topten.RichTextKit/TextBlock.cs
@@ -1334,6 +1334,9 @@ namespace Topten.RichTextKit
             {
                 return typeface == next.typeface &&
                        style.FontSize == next.style.FontSize &&
+                       style.LetterSpacing == next.style.LetterSpacing &&
+                       style.FontVariant == next.style.FontVariant &&
+                       style.LineHeight == next.style.LineHeight &&
                         asFallbackFor == next.asFallbackFor &&
                         direction == next.direction &&
                         start + length == next.start;

--- a/Topten.RichTextKit/TextLine.cs
+++ b/Topten.RichTextKit/TextLine.cs
@@ -382,11 +382,11 @@ namespace Topten.RichTextKit
             }
         }
 
-        internal void UpdateOverhang(float right, ref float leftOverhang, ref float rightOverhang)
+        internal void UpdateOverhang(float right, bool updateTop, bool updateBottom, ref float leftOverhang, ref float rightOverhang, ref float topOverhang, ref float bottomOverhang)
         {
             foreach (var r in Runs)
             {
-                r.UpdateOverhang(right, ref leftOverhang, ref rightOverhang);
+                r.UpdateOverhang(right, updateTop, updateBottom, ref leftOverhang, ref rightOverhang, ref topOverhang, ref bottomOverhang);
             }
         }
 

--- a/Topten.RichTextKit/Topten.RichTextKit.csproj
+++ b/Topten.RichTextKit/Topten.RichTextKit.csproj
@@ -1,31 +1,53 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../buildtools/Topten.props" />
+	<Import Project="../buildtools/Topten.props" />
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1;net462;net5.0</TargetFrameworks>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netcoreapp2.1;net462;net5.0</TargetFrameworks>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)'=='Release'">
-    <TtsCodeSign>True</TtsCodeSign>
-    <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/toptensoftware/richtextkit</PackageProjectUrl>
-    <PackageIcon>nuget-icon.png</PackageIcon>
-    <PackageTags>rich text, rich, text, Skia, SkiaSharp, Font</PackageTags>
-    <Description>Easy to use rich text rendering for SkiaSharp, including font-fallback, bi-directional text support and more...</Description>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <RepositoryUrl>https://github.com/toptensoftware/richtextkit</RepositoryUrl>
-  </PropertyGroup>
+	<!-- Set the LangVersion = 8 -->
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+		<LangVersion>8.0</LangVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="SkiaSharp" Version="2.88.3" />
-    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.3" />
-  </ItemGroup>
+	<!-- Only enable nullable feature for the supported frameworks -->
+	<PropertyGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+	<PropertyGroup Condition=" $(Nullable) != 'enable' ">
+		<NoWarn>$(NoWarn);CS8632</NoWarn>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)'=='Release'">
+		<TtsCodeSign>True</TtsCodeSign>
+		<GenerateDocumentationFile>True</GenerateDocumentationFile>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+		<PackageProjectUrl>https://github.com/toptensoftware/richtextkit</PackageProjectUrl>
+		<PackageIcon>nuget-icon.png</PackageIcon>
+		<PackageTags>rich text, rich, text, Skia, SkiaSharp, Font</PackageTags>
+		<Description>Easy to use rich text rendering for SkiaSharp, including font-fallback, bi-directional text support and more...</Description>
+		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+		<RepositoryUrl>https://github.com/toptensoftware/richtextkit</RepositoryUrl>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
+		<WarningLevel>2</WarningLevel>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
+		<WarningLevel>2</WarningLevel>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="SkiaSharp" Version="2.88.3" />
+		<PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.3" />
+	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
1) I also fixed a few mistakes I've seen in the code, a null test on the wrong variable, and missing halo test in IStyleExtensions.
2) I fixed text shapping issue (see https://github.com/toptensoftware/RichTextKit/issues/81 and https://github.com/toptensoftware/RichTextKit/issues/80)
3) I improved MeasureOverhang, it now also compute top and bottom when Style.LineHeight is less than 1.
4) I added MeasureOverhang in TextDocument.
5) I added two new methods to TextDocument for Extracting StyledText and Replacing text with StyledText. See below:

```
public StyledText Extract(TextRange range)
public void ReplaceText(ITextDocumentView view, TextRange range, StyledText styledText, EditSemantics semantics)
```
The first one allow to extract a range of the document as StyledText, the paragraph separators are replaced by new lines
The second one is an additional ReplaceText that take a styledText directly in input, the new lines are replaced by paragraph separator.

I need those two methods in order to build a RichTextBox control, to apply a style to a range of text. Basically to update a range of rich text, I call extract to retrieve a styled text of the selection, then I modify the styles in this StyledText (or a copy of it), and finally I call ReplaceText to update the document.

6) Last things, I wasn't able to compile the project as nullable was no available in c# 7.3 to I updated to c# 8 as advised by the compiler, please tell me if that is ok for you?