### PR TITLE
Fixed GetStyleAtOffset in TextDocument

### DIFF
--- a/Topten.RichTextKit/Editor/TextDocument.cs
+++ b/Topten.RichTextKit/Editor/TextDocument.cs
@@ -415,7 +415,7 @@ namespace Topten.RichTextKit.Editor
                 throw new NotImplementedException();
 
             // Get style from text block
-            return para.TextBlock.GetStyleAtOffset(offset);
+            return para.TextBlock.GetStyleAtOffset(indexInPara);
         }
 
         /// <summary>


### PR DESCRIPTION
TextBlock.GetStyleAtOffset was not called with the correct offset in TextDocument.GetStyleAtOffset.
