### PR TITLE
Update dependencies SkiaSharp and SkiaSharp.HarfBuzz to 3.119.0, and HarfBuzzSharp.NativeAssets to 8.3.1.1. Replace the deprecated methods marked with SkiaSharp3.0 in the project with new ones.

### DIFF
--- a/RichStringSandbox/Form1.cs
+++ b/RichStringSandbox/Form1.cs
@@ -108,20 +108,19 @@ namespace RichStringSandbox
             _richString.MaxHeight = height;
 
             var state = $"Measured: {_richString.MeasuredWidth} x {_richString.MeasuredHeight} Lines: {_richString.LineCount} Truncated: {_richString.Truncated} Length: {_richString.MeasuredLength} Revision: {_richString.Revision}";
-            canvas.DrawText(state, margin, 20, new SKPaint()
+            using (var font = new SKFont(SKTypeface.FromFamilyName("Arial"),12))
             {
-                Typeface = SKTypeface.FromFamilyName("Arial"),
-                TextSize = 12,
-                IsAntialias = true,
-            });
+                canvas.DrawText(state, margin, 20, font, new SKPaint()
+                {
+                    IsAntialias = true,
+                });
 
-            state = $"Hit Test: Over {_htr.OverCodePointIndex} Line {_htr.OverLine}.  Closest: {_htr.ClosestCodePointIndex} Line {_htr.ClosestLine}";
-            canvas.DrawText(state, margin, 40, new SKPaint()
-            {
-                Typeface = SKTypeface.FromFamilyName("Arial"),
-                TextSize = 12,
-                IsAntialias = true,
-            });
+                state = $"Hit Test: Over {_htr.OverCodePointIndex} Line {_htr.OverLine}.  Closest: {_htr.ClosestCodePointIndex} Line {_htr.ClosestLine}";
+                canvas.DrawText(state, margin, 40,font, new SKPaint()
+                {
+                    IsAntialias = true,
+                });
+            }
 
             var options = new TextPaintOptions()
             {

--- a/RichStringSandbox/RichStringSandbox.csproj
+++ b/RichStringSandbox/RichStringSandbox.csproj
@@ -97,7 +97,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.7" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Sandbox/Sandbox.csproj
+++ b/Sandbox/Sandbox.csproj
@@ -101,7 +101,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.7" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/SandboxDriver/SandboxDriver.cs
+++ b/SandboxDriver/SandboxDriver.cs
@@ -334,33 +334,29 @@ namespace SandboxDriver
                     canvas.DrawLine(rect.Right, rect.Top, rect.Left, rect.Bottom, paint);
                 }
             }
-
-            var state = $"Size: {width} x {height} Base Direction: {BaseDirection} Alignment: {TextAlignment} Content: {ContentMode} scale: {Scale} time: {elapsed} subpixel: {SubpixelPositioning} hinting: {Hinting} edging: {Edging}";
-            canvas.DrawText(state, margin, 20, new SKPaint()
+            using (var font = new SKFont(SKTypeface.FromFamilyName("Arial"), 12))
             {
-                Typeface = SKTypeface.FromFamilyName("Arial"),
-                TextSize = 12,
-                IsAntialias = true,
-            });
+                var state = $"Size: {width} x {height} Base Direction: {BaseDirection} Alignment: {TextAlignment} Content: {ContentMode} scale: {Scale} time: {elapsed} subpixel: {SubpixelPositioning} hinting: {Hinting} edging: {Edging}";
+                canvas.DrawText(state, margin, 20, font, new SKPaint()
+                {
+                    IsAntialias = true,
+                });
 
-            if (options.Selection.HasValue)
-                state = $"Selection: {options.Selection.Value.Start}-{options.Selection.Value.End} Closest: {(htr.HasValue ? htr.Value.ClosestCodePointIndex.ToString() : "-")}";
-            else
-                state = $"Selection: none";
-            canvas.DrawText(state, margin, 40, new SKPaint()
-            {
-                Typeface = SKTypeface.FromFamilyName("Arial"),
-                TextSize = 12,
-                IsAntialias = true,
-            });
+                if (options.Selection.HasValue)
+                    state = $"Selection: {options.Selection.Value.Start}-{options.Selection.Value.End} Closest: {(htr.HasValue ? htr.Value.ClosestCodePointIndex.ToString() : "-")}";
+                else
+                    state = $"Selection: none";
+                canvas.DrawText(state, margin, 40, font, new SKPaint()
+                {
+                    IsAntialias = true,
+                });
 
-            state = $"Measured: {_textBlock.MeasuredWidth} x {_textBlock.MeasuredHeight} Lines: {_textBlock.Lines.Count} Truncated: {_textBlock.Truncated}";
-            canvas.DrawText(state, margin, 60, new SKPaint()
-            {
-                Typeface = SKTypeface.FromFamilyName("Arial"),
-                TextSize = 12,
-                IsAntialias = true,
-            });
+                state = $"Measured: {_textBlock.MeasuredWidth} x {_textBlock.MeasuredHeight} Lines: {_textBlock.Lines.Count} Truncated: {_textBlock.Truncated}";
+                canvas.DrawText(state, margin, 60, font, new SKPaint()
+                {
+                    IsAntialias = true,
+                });
+            } 
         }
 
         float _hitTestX;

--- a/SandboxDriver/SandboxDriver.csproj
+++ b/SandboxDriver/SandboxDriver.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SkiaSharp" Version="2.88.7" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Topten.RichTextKit.Test/Topten.RichTextKit.Test.csproj
+++ b/Topten.RichTextKit.Test/Topten.RichTextKit.Test.csproj
@@ -10,11 +10,11 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SkiaSharp" Version="2.88.7" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Topten.RichTextKit.Test/WordBoundaryTest.cs
+++ b/Topten.RichTextKit.Test/WordBoundaryTest.cs
@@ -92,6 +92,32 @@ namespace Topten.RichTextKit.Test
         }
 
         [Fact]
+        public void Punctuation3()
+        {
+            var str = ".Hello World";
+            var boundaries = WordBoundaryAlgorithm.FindWordBoundaries(new Utf32Buffer(str).AsSlice()).ToList();
+
+            Assert.Equal(3, boundaries.Count);
+            Assert.Equal(0, boundaries[0]);
+            Assert.Equal(1, boundaries[1]);
+            Assert.Equal(7, boundaries[2]);
+        }
+
+        [Fact]
+        public void Punctuation4()
+        {
+            var str = ".Hello.World.";
+            var boundaries = WordBoundaryAlgorithm.FindWordBoundaries(new Utf32Buffer(str).AsSlice()).ToList();
+
+            Assert.Equal(5, boundaries.Count);
+            Assert.Equal(0, boundaries[0]);
+            Assert.Equal(1, boundaries[1]);
+            Assert.Equal(6, boundaries[2]);
+            Assert.Equal(7, boundaries[3]);
+            Assert.Equal(12, boundaries[4]);
+        }
+
+        [Fact]
         public void TestIsWordBoundary()
         {
             var str = new Utf32Buffer("Hello () World").AsSlice();

--- a/Topten.RichTextKit/FontRun.cs
+++ b/Topten.RichTextKit/FontRun.cs
@@ -497,45 +497,49 @@ namespace Topten.RichTextKit
 
             using (var paint = new SKPaint())
             {
-                float glyphScale = 1;
-                if (Style.FontVariant == FontVariant.SuperScript)
+                using (var font = new SKFont())
                 {
-                    glyphScale = 0.65f;
-                }
-                if (Style.FontVariant == FontVariant.SubScript)
-                {
-                    glyphScale = 0.65f;
-                }
-
-                paint.TextEncoding = SKTextEncoding.GlyphId;
-                paint.Typeface = Typeface;
-                paint.TextSize = Style.FontSize * glyphScale;
-                paint.SubpixelText = true;
-                paint.IsAntialias = true;
-                paint.LcdRenderText = false;
-
-                unsafe
-                {
-                    fixed (ushort* pGlyphs = Glyphs.Underlying)
+                    float glyphScale = 1;
+                    if (Style.FontVariant == FontVariant.SuperScript)
                     {
-                        paint.GetGlyphWidths((IntPtr)(pGlyphs + Start), sizeof(ushort) * Glyphs.Length, out var bounds);
-                        if (bounds != null)
+                        glyphScale = 0.65f;
+                    }
+                    if (Style.FontVariant == FontVariant.SubScript)
+                    {
+                        glyphScale = 0.65f;
+                    }
+
+                    paint.IsAntialias = true;
+                    font.Typeface = Typeface;
+                    font.Size = Style.FontSize * glyphScale;
+                    font.Subpixel = true;
+                    font.Edging = SKFontEdging.Antialias;
+
+                    unsafe
+                    {
+                        fixed (ushort* pGlyphs = Glyphs.Underlying)
                         {
-                            for (int i = 0; i < bounds.Length; i++)
+
+                            font.GetGlyphWidths((IntPtr)(pGlyphs + Start), sizeof(ushort) * Glyphs.Length, SKTextEncoding.GlyphId, out var bounds, paint);
+                            if (bounds != null)
                             {
-                                float gx = GlyphPositions[i].X;
+                                for (int i = 0; i < bounds.Length; i++)
+                                {
+                                    float gx = GlyphPositions[i].X;
 
-                                var loh = -(gx + bounds[i].Left);
-                                if (loh > leftOverhang)
-                                    leftOverhang = loh;
+                                    var loh = -(gx + bounds[i].Left);
+                                    if (loh > leftOverhang)
+                                        leftOverhang = loh;
 
-                                var roh = (gx + bounds[i].Right + 1) - right;
-                                if (roh > rightOverhang)
-                                    rightOverhang = roh;
+                                    var roh = (gx + bounds[i].Right + 1) - right;
+                                    if (roh > rightOverhang)
+                                        rightOverhang = roh;
+                                }
                             }
                         }
                     }
                 }
+
             }
         }
 

--- a/Topten.RichTextKit/LineBreakAlgorithm/WordBoundaryAlgorithm.cs
+++ b/Topten.RichTextKit/LineBreakAlgorithm/WordBoundaryAlgorithm.cs
@@ -77,6 +77,8 @@ namespace Topten.RichTextKit
                         // Switch to a different word kind without a space
                         // just emit a word boundary here
                         yield return i;
+                        // Update wordGroup to the new boundary class
+                        wordGroup = bg;
                     }
                 }
             }

--- a/Topten.RichTextKit/TextShaping/TextShaper.cs
+++ b/Topten.RichTextKit/TextShaping/TextShaper.cs
@@ -75,21 +75,20 @@ namespace Topten.RichTextKit
             }
 
             // Get font metrics for this typeface
-            using (var paint = new SKPaint())
+            using (var font = new SKFont())
             {
-                paint.Typeface = typeface;
-                paint.TextSize = overScale;
-                _fontMetrics = paint.FontMetrics;
+                font.Typeface = typeface;
+                font.Size = overScale;
+                _fontMetrics = font.Metrics;
 
                 // This is a temporary hack until SkiaSharp exposes
                 // a way to check if a font is fixed pitch.  For now
                 // we just measure and `i` and a `w` and see if they're
                 // the same width.
-                float[] widths = paint.GetGlyphWidths("iw", out var rects);
+                float[] widths = font.GetGlyphWidths("iw", out var rects);
                 _isFixedPitch = widths != null && widths.Length > 1 && widths[0] == widths[1];
                 if (_isFixedPitch)
                     _fixedCharacterWidth = widths[0];
-
             }
         }
 

--- a/Topten.RichTextKit/Topten.RichTextKit.csproj
+++ b/Topten.RichTextKit/Topten.RichTextKit.csproj
@@ -20,15 +20,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="2.8.2.3" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="HarfBuzzSharp.NativeAssets.Linux" Version="8.3.1.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SkiaSharp" Version="2.88.7" />
-    <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.7" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.7" />
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <PackageReference Include="SkiaSharp" Version="3.119.0" />
+    <PackageReference Include="SkiaSharp.HarfBuzz" Version="3.119.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.6.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update dependencies SkiaSharp and SkiaSharp.HarfBuzz to 3.119.0, and HarfBuzzSharp.NativeAssets to 8.3.1.1. Replace the deprecated methods marked with SkiaSharp3.0 in the project with new ones.