### PR TITLE
Fixes word boundaries when string starts with punctuation

### DIFF
--- a/Topten.RichTextKit.Test/WordBoundaryTest.cs
+++ b/Topten.RichTextKit.Test/WordBoundaryTest.cs
@@ -92,6 +92,32 @@ namespace Topten.RichTextKit.Test
         }
 
         [Fact]
+        public void Punctuation3()
+        {
+            var str = ".Hello World";
+            var boundaries = WordBoundaryAlgorithm.FindWordBoundaries(new Utf32Buffer(str).AsSlice()).ToList();
+
+            Assert.Equal(3, boundaries.Count);
+            Assert.Equal(0, boundaries[0]);
+            Assert.Equal(1, boundaries[1]);
+            Assert.Equal(7, boundaries[2]);
+        }
+
+        [Fact]
+        public void Punctuation4()
+        {
+            var str = ".Hello.World.";
+            var boundaries = WordBoundaryAlgorithm.FindWordBoundaries(new Utf32Buffer(str).AsSlice()).ToList();
+
+            Assert.Equal(5, boundaries.Count);
+            Assert.Equal(0, boundaries[0]);
+            Assert.Equal(1, boundaries[1]);
+            Assert.Equal(6, boundaries[2]);
+            Assert.Equal(7, boundaries[3]);
+            Assert.Equal(12, boundaries[4]);
+        }
+
+        [Fact]
         public void TestIsWordBoundary()
         {
             var str = new Utf32Buffer("Hello () World").AsSlice();

--- a/Topten.RichTextKit/LineBreakAlgorithm/WordBoundaryAlgorithm.cs
+++ b/Topten.RichTextKit/LineBreakAlgorithm/WordBoundaryAlgorithm.cs
@@ -77,6 +77,8 @@ namespace Topten.RichTextKit
                         // Switch to a different word kind without a space
                         // just emit a word boundary here
                         yield return i;
+                        // Update wordGroup to the new boundary class
+                        wordGroup = bg;
                     }
                 }
             }


### PR DESCRIPTION
The word boundaries are not correctly computed when a string starts with a punctuation. See attached unit test.

And thanks for this project!