### PR TITLE
Remove System.ValueTuple from .netstandard and net5

### DIFF
--- a/Topten.RichTextKit/Topten.RichTextKit.csproj
+++ b/Topten.RichTextKit/Topten.RichTextKit.csproj
@@ -28,6 +28,9 @@
     <PackageReference Include="SkiaSharp" Version="2.88.7" />
     <PackageReference Include="SkiaSharp.HarfBuzz" Version="2.88.7" />
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="2.88.7" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Remove System.ValueTuple from .netstandard and net5 because ValueTuple there already exists reducing dependencies