### PR TITLE
Fix Buffer<T>.GrowBuffer() using wrong variable for allocation size

### DIFF
--- a/Topten.RichTextKit/Utils/Buffer.cs
+++ b/Topten.RichTextKit/Utils/Buffer.cs
@@ -110,7 +110,7 @@ namespace Topten.RichTextKit.Utils
                 newLength = requiredLength;
 
             // Allocate new buffer, only copying _length, not Data.Length
-            var newData = new T[requiredLength];
+            var newData = new T[newLength];
             Array.Copy(_data, 0, newData, 0, _length);
             _data = newData;
 


### PR DESCRIPTION
Fixes #103 
## Summary

`GrowBuffer()` calculated an optimal capacity in `newLength` (doubling below 1MB, linear growth above) but then allocated the new array with `requiredLength` instead, making the entire growth strategy dead code. This caused O(n) reallocations instead of O(log n), degrading sequential Add/Insert operations from O(n) amortized to O(n^2).

## Change

One-line fix in `Buffer.cs` line 113:

- Before: `var newData = new T[requiredLength];`
- - After: `var newData = new T[newLength];`
## Affected components

Buffer<T> is used throughout the library: BiDi algorithm, text shaping, Utf32Buffer, and TextDocument. Any non-trivial text processing benefits from this fix.