### PR TITLE
Round the halo stroke join to fix spiking at acute glyph corners

### DIFF
--- a/Topten.RichTextKit/FontRun.cs
+++ b/Topten.RichTextKit/FontRun.cs
@@ -648,6 +648,7 @@ namespace Topten.RichTextKit
                     paintHalo.Style = SKPaintStyle.Stroke;
                     paintHalo.StrokeWidth = Style.HaloWidth;
                     paintHalo.StrokeCap = SKStrokeCap.Square;
+                    paintHalo.StrokeJoin = SKStrokeJoin.Round;
                     if (Style.HaloBlur > 0)
                         paintHalo.MaskFilter = SKMaskFilter.CreateBlur(SKBlurStyle.Normal, Style.HaloBlur);
                 }


### PR DESCRIPTION
Fixes #113.

`paintHalo` in `FontRun.Paint()` is built as a stroke paint but never sets `StrokeJoin`, so it falls back to Skia's default `Miter` join. That's unbounded until the default miter limit kicks in, which is what causes the long spikes at acute glyph corners (V, W, Y, A, K, 1, ! etc). Setting it to `Round` fixes it, same approach browser `-webkit-text-stroke` and Unity TextMeshPro use for text outlines.

One-line change, no other behavior affected.

Before (halo=8, sizes 8/16/32/64):

<img width="2685" height="426" alt="richtextkit-halo-spike-baseline" src="https://github.com/user-attachments/assets/ba8fa0c5-a37b-45f5-b5d5-2f1fd686c5d9" />

After:

<img width="2685" height="426" alt="richtextkit-halo-spike-baseline-PATCHED" src="https://github.com/user-attachments/assets/36dab108-3cfe-4417-ae56-287e790d0493" />

